### PR TITLE
Update build setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "homepage": "https://github.com/changchanghwang/douh#readme",
   "scripts": {
     "build": "npm run build:esm && npm run build:cjs",
-    "build:esm": "tsc --project tsconfig.build.json && tsc-alias",
-    "build:cjs": "tsc --module esnext --outDir dist/esm --project tsconfig.build.json && tsc-alias --outDir dist/esm"
+    "build:cjs": "tsc --project tsconfig.build.json && tsc-alias",
+    "build:esm": "tsc --module esnext --outDir dist/esm --project tsconfig.build.json && tsc-alias --outDir dist/esm"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/esm/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
   "homepage": "https://github.com/changchanghwang/douh#readme",
   "scripts": {
     "build": "npm run build:esm && npm run build:cjs",
-    "build:esm": "tsc && tsc-alias",
-    "build:cjs": "tsc --module commonjs --outDir dist/cjs && tsc-alias --outDir dist/cjs"
+    "build:esm": "tsc --project tsconfig.build.json && tsc-alias",
+    "build:cjs": "tsc --module esnext --outDir dist/esm --project tsconfig.build.json && tsc-alias --outDir dist/esm"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./dist/index.d.ts",
-  "esm": "./dist/index.js",
+  "types": "./dist/esm/index.d.ts",
+  "esm": "./dist/esm/index.js",
   "license": "MIT",
   "dependencies": {
     "on-finished": "^2.4.1"

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,6 @@
 {
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"],
   "compilerOptions": {
     "lib": ["es2021"],
     "target": "es2021",
@@ -18,7 +20,7 @@
     "sourceMap": true,
     "inlineSources": true,
     "baseUrl": "./src",
-    "outDir": "./dist",
+    "outDir": "./dist/cjs",
     "useUnknownInCatchVariables": false,
     "typeRoots": ["./node_modules/@types", "src/@types"]
   }


### PR DESCRIPTION
<!--
  Thank you for opening a pull request for douhjs.
-->

### Description of change
- `commonjs` is default setting of module in tsconfig → so, extra build script's outDir changed to dist/esm from dist/cjs
- added tsconfig.build.json so that test files can be excluded from package

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/douhjs/douh/blob/main/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better! 
-->
