### PR TITLE
feat: get param object when use : in endpoint

### DIFF
--- a/src/body/parser.ts
+++ b/src/body/parser.ts
@@ -7,6 +7,9 @@ declare module 'http' {
     body?: {
       [key: string]: any;
     };
+    params: {
+      [key: string]: any;
+    };
   }
   interface ServerResponse {
     body?: any;

--- a/src/router/router.test.ts
+++ b/src/router/router.test.ts
@@ -99,6 +99,20 @@ describe('router test', () => {
       expect(response2.statusCode).toBe(200);
       expect(response2.text).toBe('ok2');
     });
+
+    it('should get params object when url has params', async () => {
+      const app = getApp();
+      const router = new Router();
+
+      router.get('/ping/:name', (req, res) => {
+        return req.params;
+      });
+
+      app.use(router.middleware());
+
+      const response = await request(app.callback()).get('/ping/arthur');
+      expect(response.body).toStrictEqual({ name: 'arthur' });
+    });
   });
 
   describe('POST test', () => {
@@ -136,6 +150,20 @@ describe('router test', () => {
       expect(response.body).toStrictEqual({ name: 'Lee' });
       expect(response.text).toBe(JSON.stringify({ name: 'Lee' }));
     });
+
+    it('should get params object when url has params', async () => {
+      const app = getApp();
+      const router = new Router();
+
+      router.post('/ping/:name', (req, res) => {
+        return req.params;
+      });
+
+      app.use(router.middleware());
+
+      const response = await request(app.callback()).post('/ping/arthur');
+      expect(response.body).toStrictEqual({ name: 'arthur' });
+    });
   });
 
   describe('PATCH test', () => {
@@ -171,6 +199,20 @@ describe('router test', () => {
       expect(response.body).toStrictEqual({ name: 'Lee' });
       expect(response.text).toBe(JSON.stringify({ name: 'Lee' }));
     });
+
+    it('should get params object when url has params', async () => {
+      const app = getApp();
+      const router = new Router();
+
+      router.patch('/ping/:name', (req, res) => {
+        return req.params;
+      });
+
+      app.use(router.middleware());
+
+      const response = await request(app.callback()).patch('/ping/arthur');
+      expect(response.body).toStrictEqual({ name: 'arthur' });
+    });
   });
 
   describe('DELETE test', () => {
@@ -188,6 +230,20 @@ describe('router test', () => {
       expect(response.status).toBe(200);
       expect(response.body).toStrictEqual({ message: 'deleted' });
       expect(response.text).toBe(JSON.stringify({ message: 'deleted' }));
+    });
+
+    it('should get params object when url has params', async () => {
+      const app = getApp();
+      const router = new Router();
+
+      router.delete('/ping/:name', (req, res) => {
+        return req.params;
+      });
+
+      app.use(router.middleware());
+
+      const response = await request(app.callback()).delete('/ping/arthur');
+      expect(response.body).toStrictEqual({ name: 'arthur' });
     });
   });
 
@@ -218,6 +274,20 @@ describe('router test', () => {
 
       const response = await request(app.callback()).head('/ping');
       expect(response.headers.connection).toBe('Keep-Alive');
+    });
+
+    it('should get params object when url has params', async () => {
+      const app = getApp();
+      const router = new Router();
+
+      router.head('/ping/:name', (req, res) => {
+        res.setHeader('name', req.params.name);
+      });
+
+      app.use(router.middleware());
+
+      const response = await request(app.callback()).head('/ping/arthur');
+      expect(response.headers.name).toBe('arthur');
     });
   });
 
@@ -253,6 +323,20 @@ describe('router test', () => {
       expect(response.status).toBe(200);
       expect(response.body).toStrictEqual({ name: 'Lee' });
       expect(response.text).toBe(JSON.stringify({ name: 'Lee' }));
+    });
+
+    it('should get params object when url has params', async () => {
+      const app = getApp();
+      const router = new Router();
+
+      router.put('/ping/:name', (req, res) => {
+        return req.params;
+      });
+
+      app.use(router.middleware());
+
+      const response = await request(app.callback()).put('/ping/arthur');
+      expect(response.body).toStrictEqual({ name: 'arthur' });
     });
   });
 });

--- a/src/router/router.test.ts
+++ b/src/router/router.test.ts
@@ -113,6 +113,34 @@ describe('router test', () => {
       const response = await request(app.callback()).get('/ping/arthur');
       expect(response.body).toStrictEqual({ name: 'arthur' });
     });
+
+    it('should get params object when url has params between routes', async () => {
+      const app = getApp();
+      const router = new Router();
+
+      router.get('/user/:name/profile', (req, res) => {
+        return req.params;
+      });
+
+      app.use(router.middleware());
+
+      const response = await request(app.callback()).get('/user/arthur/profile');
+      expect(response.body).toStrictEqual({ name: 'arthur' });
+    });
+
+    it('should get multi params object when url has params', async () => {
+      const app = getApp();
+      const router = new Router();
+
+      router.get('/user/:name/profile/:id', (req, res) => {
+        return req.params;
+      });
+
+      app.use(router.middleware());
+
+      const response = await request(app.callback()).get('/user/arthur/profile/1');
+      expect(response.body).toStrictEqual({ name: 'arthur', id: '1' });
+    });
   });
 
   describe('POST test', () => {
@@ -164,6 +192,34 @@ describe('router test', () => {
       const response = await request(app.callback()).post('/ping/arthur');
       expect(response.body).toStrictEqual({ name: 'arthur' });
     });
+
+    it('should get params object when url has params between routes', async () => {
+      const app = getApp();
+      const router = new Router();
+
+      router.post('/user/:name/profile', (req, res) => {
+        return req.params;
+      });
+
+      app.use(router.middleware());
+
+      const response = await request(app.callback()).post('/user/arthur/profile');
+      expect(response.body).toStrictEqual({ name: 'arthur' });
+    });
+
+    it('should get multi params object when url has params', async () => {
+      const app = getApp();
+      const router = new Router();
+
+      router.post('/user/:name/profile/:id', (req, res) => {
+        return req.params;
+      });
+
+      app.use(router.middleware());
+
+      const response = await request(app.callback()).post('/user/arthur/profile/1');
+      expect(response.body).toStrictEqual({ name: 'arthur', id: '1' });
+    });
   });
 
   describe('PATCH test', () => {
@@ -213,6 +269,34 @@ describe('router test', () => {
       const response = await request(app.callback()).patch('/ping/arthur');
       expect(response.body).toStrictEqual({ name: 'arthur' });
     });
+
+    it('should get params object when url has params between routes', async () => {
+      const app = getApp();
+      const router = new Router();
+
+      router.patch('/user/:name/profile', (req, res) => {
+        return req.params;
+      });
+
+      app.use(router.middleware());
+
+      const response = await request(app.callback()).patch('/user/arthur/profile');
+      expect(response.body).toStrictEqual({ name: 'arthur' });
+    });
+
+    it('should get multi params object when url has params', async () => {
+      const app = getApp();
+      const router = new Router();
+
+      router.patch('/user/:name/profile/:id', (req, res) => {
+        return req.params;
+      });
+
+      app.use(router.middleware());
+
+      const response = await request(app.callback()).patch('/user/arthur/profile/1');
+      expect(response.body).toStrictEqual({ name: 'arthur', id: '1' });
+    });
   });
 
   describe('DELETE test', () => {
@@ -244,6 +328,34 @@ describe('router test', () => {
 
       const response = await request(app.callback()).delete('/ping/arthur');
       expect(response.body).toStrictEqual({ name: 'arthur' });
+    });
+
+    it('should get params object when url has params between routes', async () => {
+      const app = getApp();
+      const router = new Router();
+
+      router.delete('/user/:name/profile', (req, res) => {
+        return req.params;
+      });
+
+      app.use(router.middleware());
+
+      const response = await request(app.callback()).delete('/user/arthur/profile');
+      expect(response.body).toStrictEqual({ name: 'arthur' });
+    });
+
+    it('should get multi params object when url has params', async () => {
+      const app = getApp();
+      const router = new Router();
+
+      router.delete('/user/:name/profile/:id', (req, res) => {
+        return req.params;
+      });
+
+      app.use(router.middleware());
+
+      const response = await request(app.callback()).delete('/user/arthur/profile/1');
+      expect(response.body).toStrictEqual({ name: 'arthur', id: '1' });
     });
   });
 
@@ -288,6 +400,36 @@ describe('router test', () => {
 
       const response = await request(app.callback()).head('/ping/arthur');
       expect(response.headers.name).toBe('arthur');
+    });
+
+    it('should get params object when url has params between routes', async () => {
+      const app = getApp();
+      const router = new Router();
+
+      router.head('/user/:name/profile', (req, res) => {
+        res.setHeader('name', req.params.name);
+      });
+
+      app.use(router.middleware());
+
+      const response = await request(app.callback()).head('/user/arthur/profile');
+      expect(response.headers.name).toBe('arthur');
+    });
+
+    it('should get multi params object when url has params', async () => {
+      const app = getApp();
+      const router = new Router();
+
+      router.head('/user/:name/profile/:id', (req, res) => {
+        res.setHeader('name', req.params.name);
+        res.setHeader('id', req.params.id);
+      });
+
+      app.use(router.middleware());
+
+      const response = await request(app.callback()).head('/user/arthur/profile/1');
+      expect(response.headers.name).toBe('arthur');
+      expect(response.headers.id).toBe('1');
     });
   });
 
@@ -337,6 +479,34 @@ describe('router test', () => {
 
       const response = await request(app.callback()).put('/ping/arthur');
       expect(response.body).toStrictEqual({ name: 'arthur' });
+    });
+
+    it('should get params object when url has params between routes', async () => {
+      const app = getApp();
+      const router = new Router();
+
+      router.put('/user/:name/profile', (req, res) => {
+        return req.params;
+      });
+
+      app.use(router.middleware());
+
+      const response = await request(app.callback()).put('/user/arthur/profile');
+      expect(response.body).toStrictEqual({ name: 'arthur' });
+    });
+
+    it('should get multi params object when url has params', async () => {
+      const app = getApp();
+      const router = new Router();
+
+      router.put('/user/:name/profile/:id', (req, res) => {
+        return req.params;
+      });
+
+      app.use(router.middleware());
+
+      const response = await request(app.callback()).put('/user/arthur/profile/1');
+      expect(response.body).toStrictEqual({ name: 'arthur', id: '1' });
     });
   });
 });


### PR DESCRIPTION
<!--
  Thank you for opening a pull request for douhjs.
-->

### Description of change
get paramet in endpoint when use `:`

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/douhjs/douh/blob/main/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making Douh even better!
-->
