### PR TITLE
refactor: body parse when request end event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "douh",
-  "version": "0.0.3-alpha.2",
+  "version": "0.0.3-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "douh",
-      "version": "0.0.3-alpha.2",
+      "version": "0.0.3-alpha.3",
       "license": "MIT",
       "dependencies": {
         "on-finished": "^2.4.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "douh",
-  "version": "0.0.3-alpha.2",
+  "version": "0.0.3-alpha.3",
   "description": "http based node.js web server framework",
   "author": "changchanghwnag",
   "homepage": "https://github.com/douhjs/douh",

--- a/src/body/parser.ts
+++ b/src/body/parser.ts
@@ -1,19 +1,39 @@
 import { DouhRequest, DouhResponse } from '../http';
 import { NextFunction } from '../application';
 
-const methodContainedBody = new Set(['POST', 'PUT', 'PATCH']);
+const methodsContainedBody = new Set(['POST', 'PUT', 'PATCH']);
 
-export function bodyParser(req: DouhRequest, res: DouhResponse, next: NextFunction) {
-  if (req.method && methodContainedBody.has(req.method)) {
-    const buffers: Buffer[] = [];
-    req.on('data', (chunk: Buffer) => {
-      buffers.push(chunk);
-      const payload = Buffer.concat(buffers).toString();
-      const body = JSON.parse(payload);
-      req.body = body ?? {};
+export async function bodyParser(req: DouhRequest, _: DouhResponse, next: NextFunction) {
+  if (req.method && methodsContainedBody.has(req.method)) {
+    const contentType = req.headers['content-type'];
+
+    if (contentType === 'application/json') {
+      // call next after parsing body
+      const body = await readStringifiedRequestBody(req);
+      req.body = body;
       next();
-    });
+    }
   } else {
     next();
   }
+}
+
+function readStringifiedRequestBody(req: DouhRequest) {
+  return new Promise((resolve, reject) => {
+    const buffers: Buffer[] = [];
+
+    req.on('data', (chunk: Buffer) => {
+      buffers.push(chunk);
+    });
+
+    req.on('end', () => {
+      const payload = Buffer.concat(buffers).toString();
+      const body = JSON.parse(payload);
+      resolve(body);
+    });
+
+    req.on('error', (error) => {
+      reject(error);
+    });
+  }) as Promise<Record<string, any>>;
 }


### PR DESCRIPTION
<!--
  Thank you for opening a pull request for douhjs.
-->

### Description of change
- 바디 파싱을 end event 시 하는 것으로 변경
  - data 이벤트에서 하는 경우 데이터조각이 올때마다 실행하게 되는데 end에서는 데이터가 전부 온 후에 하기때문에 시간적으로 이점을 가질 수 있음.
  - 다만 기존의 코드에서 하게되면 해당 이벤트는 비동기로 실행되기때문에 호출되기 전에 다음 미들웨어가 실행되는 경우가 있음.
  - 그래서 promise 함수를 만들어서 전부 처리된 후 next 호출하도록 변경.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/douhjs/douh/blob/main/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making Douh even better!
-->
