### PR TITLE
Return `next()` when index.html not exist in the directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "douh",
-  "version": "0.1.1-alpha.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "douh",
-      "version": "0.1.1-alpha.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "on-finished": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "douh",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "http based node.js web server framework",
   "author": "changchanghwnag",
   "homepage": "https://github.com/douhjs/douh",

--- a/src/static/index.ts
+++ b/src/static/index.ts
@@ -30,10 +30,14 @@ export function serveStatic(baseRoute: string) {
     if (!exist) {
       return next();
     }
-    let stat = fs.statSync(filePath);
+    const stat = fs.statSync(filePath);
     if (stat.isDirectory()) {
       filePath = path.join(filePath, 'index.html');
-      stat = await asyncFs.stat(filePath);
+
+      const exist = fs.existsSync(filePath);
+      if (!exist) {
+        return next();
+      }
     }
 
     const data = await asyncFs.readFile(filePath);


### PR DESCRIPTION
<!--
  Thank you for opening a pull request for douhjs.
-->

### Description of change

There was `Internal Server` error when `index.html` does not exist in the directory when serving static files.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/douhjs/douh/blob/main/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making Douh even better!
-->
